### PR TITLE
padding and square aspect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+
+.idea/

--- a/pplot
+++ b/pplot
@@ -6,10 +6,12 @@ import re
 import getopt
 
 marker = '.'
-opts, args = getopt.getopt(sys.argv[1:], 'l')
+opts, args = getopt.getopt(sys.argv[1:], 'l:S')
 for o, a in opts:
   if o == '-l':
     marker = '.-'
+  elif o == '-S':
+    plt.gca().set_aspect(1.0)
 
 x = []
 y = []   
@@ -21,10 +23,6 @@ for line in sys.stdin:
 plt.plot(x, y, marker)
 plt.minorticks_on()
 plt.grid(which='both', color='#aaaaaa')
-
 # add a little bit of margin around the figure so that minimal/maximal points are easier to see
 plt.margins(0.05)
-# set the aspect ratio to square, so that circles look like circles
-plt.gca().set_aspect(1.0)
-
 plt.savefig(sys.stdout, format='png')

--- a/pplot
+++ b/pplot
@@ -6,7 +6,7 @@ import re
 import getopt
 
 marker = '.'
-opts, args = getopt.getopt(sys.argv[1:], 'l:S')
+opts, args = getopt.getopt(sys.argv[1:], 'lS')
 for o, a in opts:
   if o == '-l':
     marker = '.-'

--- a/pplot
+++ b/pplot
@@ -21,4 +21,10 @@ for line in sys.stdin:
 plt.plot(x, y, marker)
 plt.minorticks_on()
 plt.grid(which='both', color='#aaaaaa')
+
+# add a little bit of margin around the figure so that minimal/maximal points are easier to see
+plt.margins(0.05)
+# set the aspect ratio to square, so that circles look like circles
+plt.gca().set_aspect(1.0)
+
 plt.savefig(sys.stdout, format='png')


### PR DESCRIPTION
this PR makes two changes:

1) adds a small margin around the points so that minimal/maximal points are not right on the border of the image, which makes them difficult to see.

2) adds a command-line option '-S' which sets the aspect ratio of the plot to be 1:1, so that circles look like circles instead of ellipses.

It also adds a .gitignore file for some common files which should not be in git.